### PR TITLE
Add new blog post: Adjust the display brightness from command-line for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@
 - [Deploy Scalable and Highly Available Web App (Omaha Server) on AWS Cloud](https://medium.com/@ptuladhar3/deploy-scalable-and-highly-available-web-app-omaha-server-on-aws-cloud-69e26df7c85b)
 - [Email Productivity: Organize your Gmail Labels as Tabs](https://medium.com/@ptuladhar3/email-productivity-organize-your-gmail-labels-as-tabs-3c29acc7b350)
 - [Linux Commands for Developers](https://medium.com/@ptuladhar3/linux-commands-for-developers-d88baba576b4)
+- [Adjust the display brightness from command-line for Linux](https://dev.to/ptuladhar3/adjust-the-display-brightness-from-command-line-for-linux-3k86)


### PR DESCRIPTION
Add new blogpost titled "Adjust the display brightness from command-line for Linux" to showcase.

Read on dev.to:
- https://dev.to/ptuladhar3/adjust-the-display-brightness-from-command-line-for-linux-3k86